### PR TITLE
Fix description

### DIFF
--- a/templates/dellos10_interface.j2
+++ b/templates/dellos10_interface.j2
@@ -9,7 +9,7 @@ dellos_interface:
             desc: "OS10 intf"
             portmode: trunk
             mtu: 2000
-            switchport: False
+            switchport: True
             admin: up
 #            ip_type_dynamic: True
             ip_and_mask: "192.168.11.1/24"
@@ -53,7 +53,11 @@ no interface breakout {{ port[1] }}
 interface {{ interface_key }}
   {% if intf_vars.desc is defined %}
     {% if intf_vars.desc %}
+       {% if intf_vars.desc|wordcount > 1 %}
  description "{{ intf_vars.desc }}"
+       {% else %} 
+ description {{ intf_vars.desc }}
+       {% endif %}
     {% else %}
  no description
     {% endif %}
@@ -63,19 +67,9 @@ interface {{ interface_key }}
     {% if intf_vars.switchport %}
       {% if intf_vars.portmode is defined and intf_vars.portmode %}
  switchport mode {{ intf_vars.portmode }}
-      {% else %}
- switchport mode access
       {% endif %}
     {% else %}
  no switchport
-    {% endif %}
-  {% else %}
-    {% if intf_vars.portmode is defined %}
-      {% if intf_vars.portmode %}
- switchport mode {{ intf_vars.portmode }}
-      {% else %}
- no switchport
-      {% endif %}
     {% endif %}
   {% endif %}
 

--- a/templates/dellos10_interface.j2
+++ b/templates/dellos10_interface.j2
@@ -9,7 +9,7 @@ dellos_interface:
             desc: "OS10 intf"
             portmode: trunk
             mtu: 2000
-            switchport: True
+            switchport: False
             admin: up
 #            ip_type_dynamic: True
             ip_and_mask: "192.168.11.1/24"

--- a/templates/dellos10_interface.j2
+++ b/templates/dellos10_interface.j2
@@ -63,6 +63,8 @@ interface {{ interface_key }}
     {% endif %}
   {% endif %}
 
+
+
   {% if intf_vars.switchport is defined %}
     {% if intf_vars.switchport %}
       {% if intf_vars.portmode is defined and intf_vars.portmode %}
@@ -70,6 +72,14 @@ interface {{ interface_key }}
       {% endif %}
     {% else %}
  no switchport
+    {% endif %}
+  {% else %}
+    {% if intf_vars.portmode is defined %}
+      {% if intf_vars.portmode %}
+ switchport mode {{ intf_vars.portmode }}
+      {% else %}
+ no switchport
+      {% endif %}
     {% endif %}
   {% endif %}
 


### PR DESCRIPTION
Please review fix for commas in interface description.
It places commas only for multiple words in 'desc' variable.

Please review fix for 'switchport: True' value. In this case it is nor required to add 'switchport mode access' as it is not visible under 'interface' by default if configured. Otherwise it is always changing that to 'switchport mode access' for every run.
This change requires to explicitly assign 'portmode: access' in case of changing the port from 'no switchport' to 'switchport'. Which can be documented in example.

Thank you in advance